### PR TITLE
doc: helm oci incorrect

### DIFF
--- a/charts/ricochet/README.md
+++ b/charts/ricochet/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```sh
-helm install ricochet oci://reg.ricochet.rs/ricochet/ricochet-helm
+helm install ricochet oci://ghcr.io/ricochet-rs/ricochet-helm
 ```
 
 The installation and configuration instructions can be found in [the ricochet documentation](https://docs.ricochet.rs/admin/installation/4-helm/index.html).


### PR DESCRIPTION
Trying to install the helm chart per the readme results in a 403 error. This is because we have the wrong OCI path. 

It should be `oci://reg.ricochet.rs/ricochet/ricochet-helm`