### PR TITLE
feat: add OpenShift support with non-root security defaults

### DIFF
--- a/charts/ricochet/templates/_helpers.tpl
+++ b/charts/ricochet/templates/_helpers.tpl
@@ -77,3 +77,13 @@ Return the proper image pull policy
 {{- define "ricochet.imagePullPolicy" -}}
 {{- .Values.image.pullPolicy | default "IfNotPresent" -}}
 {{- end }}
+
+{{/*
+Return the init container image name
+*/}}
+{{- define "ricochet.initContainerImage" -}}
+{{- $registry := .Values.initContainerImage.registry -}}
+{{- $repository := .Values.initContainerImage.repository -}}
+{{- $tag := .Values.initContainerImage.tag -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end }}

--- a/charts/ricochet/templates/deployment.yaml
+++ b/charts/ricochet/templates/deployment.yaml
@@ -47,15 +47,17 @@ spec:
       initContainers:
         {{- if .Values.persistence.home.enabled }}
         - name: fix-permissions
-          image: {{ .Values.busyboxImage }}
+          image: {{ include "ricochet.initContainerImage" . }}
           command: ['sh', '-c']
           args:
             - |
               mkdir -p {{ .Values.persistence.home.mountPath }}/content
-              chown -R 1000:1000 {{ .Values.persistence.home.mountPath }}
           securityContext:
-            runAsUser: 0
-            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
           volumeMounts:
             {{- if .Values.persistence.home.enabled }}
             - name: home-storage
@@ -64,7 +66,7 @@ spec:
         {{- end }}
         {{- if ne (len .Values.config) 0 }}
         - name: merge-config
-          image: {{ .Values.busyboxImage }}
+          image: {{ include "ricochet.initContainerImage" . }}
           command: ['sh', '-c']
           args:
             - |
@@ -122,11 +124,12 @@ spec:
               {{- end }}
               {{- end }}
 
-              # Set proper permissions
-              chown -R 1000:1000 /var/lib/ricochet/data
           securityContext:
-            runAsUser: 0
-            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
           volumeMounts:
             {{- if ne (len .Values.config) 0 }}
             - name: config

--- a/charts/ricochet/templates/openshift-route.yaml
+++ b/charts/ricochet/templates/openshift-route.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.openshift.route.enabled -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "ricochet.fullname" . }}
+  labels:
+    {{- include "ricochet.labels" . | nindent 4 }}
+    {{- with .Values.openshift.route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.openshift.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.openshift.route.host }}
+  host: {{ .Values.openshift.route.host | quote }}
+  {{- end }}
+  path: {{ .Values.openshift.route.path }}
+  to:
+    kind: Service
+    name: {{ include "ricochet.fullname" . }}
+    weight: 100
+  port:
+    targetPort: http
+  {{- if .Values.openshift.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.openshift.route.tls.termination }}
+    {{- if .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.openshift.route.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+    {{- if .Values.openshift.route.tls.certificate }}
+    certificate: |
+      {{- .Values.openshift.route.tls.certificate | nindent 6 }}
+    {{- end }}
+    {{- if .Values.openshift.route.tls.key }}
+    key: |
+      {{- .Values.openshift.route.tls.key | nindent 6 }}
+    {{- end }}
+    {{- if .Values.openshift.route.tls.caCertificate }}
+    caCertificate: |
+      {{- .Values.openshift.route.tls.caCertificate | nindent 6 }}
+    {{- end }}
+    {{- if .Values.openshift.route.tls.destinationCACertificate }}
+    destinationCACertificate: |
+      {{- .Values.openshift.route.tls.destinationCACertificate | nindent 6 }}
+    {{- end }}
+  {{- end }}
+  wildcardPolicy: {{ .Values.openshift.route.wildcardPolicy }}
+{{- end }}

--- a/charts/ricochet/templates/serviceaccount.yaml
+++ b/charts/ricochet/templates/serviceaccount.yaml
@@ -1,12 +1,16 @@
 {{- if .Values.serviceAccount.create -}}
+{{- $annotations := .Values.serviceAccount.annotations | default dict -}}
+{{- if .Values.openshift.scc.annotate -}}
+{{- $annotations = merge (dict "openshift.io/scc" .Values.openshift.scc.name) $annotations -}}
+{{- end -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ricochet.serviceAccountName" . }}
   labels:
     {{- include "ricochet.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- if $annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $annotations | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/ricochet/tests/openshift_route_test.yaml
+++ b/charts/ricochet/tests/openshift_route_test.yaml
@@ -1,0 +1,103 @@
+suite: openshift route
+templates:
+  - openshift-route.yaml
+tests:
+  - it: should not create Route when disabled
+    set:
+      openshift.route.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create Route when enabled
+    set:
+      openshift.route.enabled: true
+    asserts:
+      - isKind:
+          of: Route
+      - equal:
+          path: apiVersion
+          value: route.openshift.io/v1
+      - equal:
+          path: metadata.name
+          value: ricochet
+
+  - it: should set host when specified
+    set:
+      openshift.route.enabled: true
+      openshift.route.host: app.example.com
+    asserts:
+      - equal:
+          path: spec.host
+          value: app.example.com
+
+  - it: should configure TLS with edge termination by default
+    set:
+      openshift.route.enabled: true
+    asserts:
+      - equal:
+          path: spec.tls.termination
+          value: edge
+      - equal:
+          path: spec.tls.insecureEdgeTerminationPolicy
+          value: Redirect
+
+  - it: should configure passthrough TLS
+    set:
+      openshift.route.enabled: true
+      openshift.route.tls.termination: passthrough
+    asserts:
+      - equal:
+          path: spec.tls.termination
+          value: passthrough
+
+  - it: should disable TLS when tls.enabled is false
+    set:
+      openshift.route.enabled: true
+      openshift.route.tls.enabled: false
+    asserts:
+      - isNull:
+          path: spec.tls
+
+  - it: should set correct service target
+    set:
+      openshift.route.enabled: true
+    asserts:
+      - equal:
+          path: spec.to.kind
+          value: Service
+      - equal:
+          path: spec.to.name
+          value: ricochet
+      - equal:
+          path: spec.port.targetPort
+          value: http
+
+  - it: should add annotations when specified
+    set:
+      openshift.route.enabled: true
+      openshift.route.annotations:
+        haproxy.router.openshift.io/timeout: 60s
+    asserts:
+      - equal:
+          path: metadata.annotations["haproxy.router.openshift.io/timeout"]
+          value: 60s
+
+  - it: should add labels when specified
+    set:
+      openshift.route.enabled: true
+      openshift.route.labels:
+        environment: production
+    asserts:
+      - equal:
+          path: metadata.labels.environment
+          value: production
+
+  - it: should set wildcard policy
+    set:
+      openshift.route.enabled: true
+      openshift.route.wildcardPolicy: Subdomain
+    asserts:
+      - equal:
+          path: spec.wildcardPolicy
+          value: Subdomain

--- a/charts/ricochet/tests/serviceaccount_test.yaml
+++ b/charts/ricochet/tests/serviceaccount_test.yaml
@@ -1,0 +1,72 @@
+suite: serviceaccount
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should create ServiceAccount when enabled
+    set:
+      serviceAccount.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: ricochet
+
+  - it: should not create ServiceAccount when disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should add user annotations
+    set:
+      serviceAccount.create: true
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::role/test
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::role/test
+
+  - it: should add SCC annotation when openshift.scc.annotate is true
+    set:
+      serviceAccount.create: true
+      openshift.scc.annotate: true
+      openshift.scc.name: nonroot-v2
+    asserts:
+      - equal:
+          path: metadata.annotations["openshift.io/scc"]
+          value: nonroot-v2
+
+  - it: should not add SCC annotation when openshift.scc.annotate is false
+    set:
+      serviceAccount.create: true
+      openshift.scc.annotate: false
+    asserts:
+      - isNull:
+          path: metadata.annotations["openshift.io/scc"]
+
+  - it: should merge SCC annotation with user annotations
+    set:
+      serviceAccount.create: true
+      serviceAccount.annotations:
+        custom: value
+      openshift.scc.annotate: true
+      openshift.scc.name: anyuid
+    asserts:
+      - equal:
+          path: metadata.annotations["openshift.io/scc"]
+          value: anyuid
+      - equal:
+          path: metadata.annotations.custom
+          value: value
+
+  - it: should use custom ServiceAccount name
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa

--- a/charts/ricochet/values.yaml
+++ b/charts/ricochet/values.yaml
@@ -46,6 +46,15 @@ image:
 imagePullSecrets: []
 # - name: myregistrykey
 
+# initContainerImage -- Image used for init containers (fix-permissions, merge-config)
+initContainerImage:
+  # initContainerImage.registry -- Registry for the init container image
+  registry: docker.io
+  # initContainerImage.repository -- Repository for the init container image
+  repository: busybox
+  # initContainerImage.tag -- Tag for the init container image
+  tag: '1.37'
+
 apps:
   deployment:
     # apps.deployment.strategy -- Update strategy for app-spawned deployments
@@ -198,22 +207,24 @@ podAnnotations: {}
 podLabels: {}
 
 # podSecurityContext -- Security context for pods
-podSecurityContext: {}
-  # fsGroup: 1000
-  # runAsNonRoot: true
-  # runAsUser: 1000
-  # runAsGroup: 1000
+podSecurityContext:
+  fsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
 # securityContext -- Security context for containers
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #     - ALL
-  # readOnlyRootFilesystem: false
-  # allowPrivilegeEscalation: false
-  # runAsNonRoot: true
-  # runAsUser: 1000
-  # runAsGroup: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
 
 # livenessProbe -- Liveness probe configuration
 livenessProbe:
@@ -305,10 +316,6 @@ extraVolumeMounts: []
 #   mountPath: /etc/extra
 #   readOnly: true
 
-# busyboxImage -- Busybox image used by built-in init containers (fix-permissions, merge-config)
-# renovate: image
-busyboxImage: busybox:1.37
-
 # initContainers -- Additional init containers
 initContainers: []
 
@@ -330,6 +337,45 @@ telemetry:
     # jaeger.initImage -- Busybox image used by the init container to write the Jaeger config
     # renovate: image
     initImage: busybox:1.37
+
+# openshift -- OpenShift-specific configuration
+openshift:
+  # openshift.route -- OpenShift Route configuration
+  route:
+    # openshift.route.enabled -- Enable OpenShift Route resource
+    enabled: false
+    # openshift.route.host -- Hostname for the Route (leave empty for auto-generated)
+    host: ''
+    # openshift.route.path -- Path for the Route
+    path: /
+    # openshift.route.annotations -- Annotations for the Route
+    annotations: {}
+    # openshift.route.labels -- Additional labels for the Route
+    labels: {}
+    # openshift.route.tls -- TLS configuration for the Route
+    tls:
+      # openshift.route.tls.enabled -- Enable TLS on the Route
+      enabled: true
+      # openshift.route.tls.termination -- TLS termination type (edge, reencrypt, passthrough)
+      termination: edge
+      # openshift.route.tls.insecureEdgeTerminationPolicy -- Policy for insecure traffic (Allow, Redirect, None)
+      insecureEdgeTerminationPolicy: Redirect
+      # openshift.route.tls.certificate -- TLS certificate (PEM format, optional - use with edge/reencrypt)
+      certificate: ''
+      # openshift.route.tls.key -- TLS private key (PEM format, optional - use with edge/reencrypt)
+      key: ''
+      # openshift.route.tls.caCertificate -- CA certificate (PEM format, optional)
+      caCertificate: ''
+      # openshift.route.tls.destinationCACertificate -- Destination CA certificate (PEM format, optional - use with reencrypt)
+      destinationCACertificate: ''
+    # openshift.route.wildcardPolicy -- Wildcard policy (None or Subdomain)
+    wildcardPolicy: None
+  # openshift.scc -- Security Context Constraints configuration
+  scc:
+    # openshift.scc.annotate -- Annotate the ServiceAccount with the SCC name
+    annotate: false
+    # openshift.scc.name -- Name of the SCC to annotate on the ServiceAccount
+    name: nonroot-v2
 
 # networkPolicy -- Network policy configuration
 networkPolicy:


### PR DESCRIPTION
## Summary

- Reworked security context defaults to enforce non-root execution (UID 1000, `fsGroup: 1000`, `runAsNonRoot: true`, drop ALL capabilities)
- Removed root requirement from `fix-permissions` and `merge-config` init containers — no more `runAsUser: 0` or `chown` commands; volume ownership is handled via `fsGroup`
- Made init container image configurable via `initContainerImage` values (replaces hardcoded `busybox:1.37` — allows mirroring for air-gapped/enterprise environments)
- Added OpenShift Route template (`openshift.route`) with edge/reencrypt/passthrough TLS termination, annotations, labels, and wildcard policy support
- Added SCC annotation injection on ServiceAccount (`openshift.scc.annotate` / `openshift.scc.name`)
- Added 17 unit tests covering Route template and ServiceAccount SCC behavior

**BREAKING CHANGE:** `podSecurityContext` and `securityContext` now default to non-root (UID 1000). Existing deployments must use a non-root container image (requires corresponding Containerfile change with `USER 1000` and group-writable dirs) or override with `podSecurityContext: {}`.

**Companion change required:** The container image (`Containerfile.alpine`) must be updated to add `chgrp -R 0 /var/lib/ricochet && chmod -R g=u /var/lib/ricochet` and `USER 1000` before the `ENTRYPOINT`. The new image must be published before upgrading to this chart version.