### PR TITLE
feat: copy vendored renv to cache pvc

### DIFF
--- a/charts/ricochet/templates/deployment.yaml
+++ b/charts/ricochet/templates/deployment.yaml
@@ -86,6 +86,23 @@ spec:
               mountPath: {{ .Values.persistence.home.mountPath }}
             {{- end }}
         {{- end }}
+        - name: stage-vendor
+          image: {{ include "ricochet.image" . }}
+          imagePullPolicy: {{ include "ricochet.imagePullPolicy" . }}
+          command: ['sh', '-c']
+          args:
+            - |
+              mkdir -p {{ .Values.apps.deployment.persistence.cache.mountPath }}/vendor/r
+              cp /var/lib/ricochet/data/vendor/r/renv.tar.gz {{ .Values.apps.deployment.persistence.cache.mountPath }}/vendor/r/renv.tar.gz
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+          volumeMounts:
+            - name: apps-cache-storage
+              mountPath: {{ .Values.apps.deployment.persistence.cache.mountPath }}
         {{- if ne (len .Values.config) 0 }}
         - name: merge-config
           image: {{ include "ricochet.initContainerImage" . }}
@@ -349,11 +366,13 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.apps.deployment.persistence.content.existingClaim | default (printf "%s-apps-content" (include "ricochet.fullname" .)) }}
         {{- end }}
-        {{- if .Values.apps.deployment.persistence.cache.enabled }}
         - name: apps-cache-storage
+          {{- if .Values.apps.deployment.persistence.cache.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.apps.deployment.persistence.cache.existingClaim | default (printf "%s-apps-cache" (include "ricochet.fullname" .)) }}
-        {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
This PR adds an init container to the helm chart that copies the vendored `renv.tar.gz` file into the `.cache/vendor/r/renv.tar.gz` so that restore pods (and task jobs & app deployments) have access to the provided version of renv. 

See [deployment](https://dev.k8s.josi.ricochet.rs/deployments/01KS5KT9JNH43BG3MYM62HXDJK). Snippet below: 
```
> user_lib <- Sys.getenv("R_LIBS_USER")
> renv_tar <- Sys.getenv("RICOCHET_RENV_TAR")
> 
> if (!file.exists(file.path(user_lib, "renv"))) {
+   message("Installing vendored renv.")
+   install.packages(renv_tar, repos = NULL, lib = user_lib)
+ }
Installing vendored renv.
Warning in untar2(tarfile, files, list, exdir, restore_times) :
  skipping pax global extended headers
* installing *source* package ‘renv’ ...
** this is package ‘renv’ version ‘1.2.2.9000’
** using staged installation
** R
** inst
** byte-compile and prepare package for lazy loading
** help
** libs
using C compiler: ‘gcc (Alpine 15.2.0) 15.2.0’
gcc -I"/opt/R/4.5.3/lib/R/include" -DNDEBUG   -I/usr/local/include -D__MUSL__    -fpic  -g -O2  -D__MUSL__ -flax-vector-conversions -c renv.c -o renv.o
gcc -shared -L/opt/R/4.5.3/lib/R/lib -L/usr/local/lib -fPIC -o renv.so renv.o -L/opt/R/4.5.3/lib/R/lib -lR
*** installing help indices
*** copying figures
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (renv)
```


The ricochet PR needs a smidgen more work but the core change to the helm chart is the core fix! 