### PR TITLE
fix: chown the apps content and cache PVCs in fix-permissions-root

### DIFF
--- a/charts/ricochet/templates/deployment.yaml
+++ b/charts/ricochet/templates/deployment.yaml
@@ -51,7 +51,14 @@ spec:
           command: ['sh', '-c']
           args:
             - |
-              chown -R {{ .Values.podSecurityContext.runAsUser | default 1000 }}:{{ .Values.podSecurityContext.fsGroup | default 1000 }} {{ .Values.persistence.home.mountPath }}
+              UID_GID="{{ .Values.podSecurityContext.runAsUser | default 1000 }}:{{ .Values.podSecurityContext.fsGroup | default 1000 }}"
+              chown -R "$UID_GID" {{ .Values.persistence.home.mountPath }}
+              {{- if .Values.apps.deployment.persistence.content.enabled }}
+              chown -R "$UID_GID" {{ .Values.apps.deployment.persistence.content.mountPath }}
+              {{- end }}
+              {{- if .Values.apps.deployment.persistence.cache.enabled }}
+              chown -R "$UID_GID" {{ .Values.apps.deployment.persistence.cache.mountPath }}
+              {{- end }}
           securityContext:
             runAsUser: 0
             runAsNonRoot: false
@@ -66,6 +73,14 @@ spec:
           volumeMounts:
             - name: home-storage
               mountPath: {{ .Values.persistence.home.mountPath }}
+            {{- if .Values.apps.deployment.persistence.content.enabled }}
+            - name: apps-content-storage
+              mountPath: {{ .Values.apps.deployment.persistence.content.mountPath }}
+            {{- end }}
+            {{- if .Values.apps.deployment.persistence.cache.enabled }}
+            - name: apps-cache-storage
+              mountPath: {{ .Values.apps.deployment.persistence.cache.mountPath }}
+            {{- end }}
         {{- end }}
         {{- if .Values.persistence.home.enabled }}
         - name: fix-permissions

--- a/charts/ricochet/tests/fix_permissions_test.yaml
+++ b/charts/ricochet/tests/fix_permissions_test.yaml
@@ -22,7 +22,10 @@ tests:
           content: CHOWN
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: 'chown -R 1000:1000 /var/lib/ricochet/data'
+          pattern: 'UID_GID="1000:1000"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'chown -R "\$UID_GID" /var/lib/ricochet/data'
 
   - it: uses custom uid/gid from podSecurityContext
     set:
@@ -35,7 +38,64 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: 'chown -R 2000:3000 /var/lib/ricochet/data'
+          pattern: 'UID_GID="2000:3000"'
+
+  - it: also chowns and mounts the content PVC when enabled
+    set:
+      persistence:
+        home:
+          enabled: true
+      apps:
+        deployment:
+          persistence:
+            content:
+              enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'chown -R "\$UID_GID" /var/lib/ricochet/data/content'
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: apps-content-storage
+            mountPath: /var/lib/ricochet/data/content
+
+  - it: also chowns and mounts the cache PVC when enabled
+    set:
+      persistence:
+        home:
+          enabled: true
+      apps:
+        deployment:
+          persistence:
+            cache:
+              enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'chown -R "\$UID_GID" /var/lib/ricochet/data/.cache'
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: apps-cache-storage
+            mountPath: /var/lib/ricochet/data/.cache
+
+  - it: does not mount apps PVCs when they are disabled
+    set:
+      persistence:
+        home:
+          enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: apps-content-storage
+            mountPath: /var/lib/ricochet/data/content
+      - notContains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: apps-cache-storage
+            mountPath: /var/lib/ricochet/data/.cache
 
   - it: disables fix-permissions-root when explicitly set to false
     set:


### PR DESCRIPTION
## Summary

`fix-permissions-root` only mounted `home-storage` and chowned `persistence.home.mountPath`.
When `apps.deployment.persistence.content.enabled` or `apps.deployment.persistence.cache.enabled` is true those PVCs are separate volumes superimposed at `/var/lib/ricochet/data/content` and `/var/lib/ricochet/data/.cache`, so the init container's chown never reached them.

In practice the bundle directories on the content PVC stay `root:root 755` from old spawned pods that ran without a `securityContext`.
The proxy then runs as UID 1000 and fails with `Permission denied (os error 13)` when refreshing the `persistent` symlink in an existing bundle or writing into `.ricochet-logs/`.

## Repro

On a cluster with all three PVCs enabled:

```
$ kubectl exec ricochet-... -- ls -la /var/lib/ricochet/data/content/<ulid>/bundle-<ulid>/
drwxr-xr-x  4 root root  4096 Mar 19 07:02 .
...
$ kubectl exec ricochet-... -- id
uid=1000 gid=1000 groups=1000
```

`fix-permissions-root`'s `volumeMounts` only references `home-storage`, so `apps-content-storage` and `apps-cache-storage` keep whatever ownership the spawned app/restore pods (which run as the image default UID) left behind.

## Change

- Extend `fix-permissions-root` to mount each apps PVC when its `enabled` flag is set, and chown it.
- Capture the runAsUser/fsGroup expansion into a `UID_GID` shell variable so we don't repeat the templated values for each chown.

Rendered output with all three PVCs enabled:

```
- name: fix-permissions-root
  ...
  args:
    - |
      UID_GID="1000:1000"
      chown -R "$UID_GID" /var/lib/ricochet/data
      chown -R "$UID_GID" /var/lib/ricochet/data/content
      chown -R "$UID_GID" /var/lib/ricochet/data/.cache
  volumeMounts:
    - name: home-storage
      mountPath: /var/lib/ricochet/data
    - name: apps-content-storage
      mountPath: /var/lib/ricochet/data/content
    - name: apps-cache-storage
      mountPath: /var/lib/ricochet/data/.cache
```

With the apps PVCs disabled the rendered output is unchanged apart from the new `UID_GID` shell variable.

## Tests

Three new cases in `tests/fix_permissions_test.yaml`:
- content PVC enabled → extra chown + apps-content-storage mount
- cache PVC enabled → extra chown + apps-cache-storage mount
- both disabled (default) → no extra mounts

The two existing tests that grep `args[0]` for `chown -R 1000:1000 ...` are updated to match the new shell-variable form.

## Related

Pairs with [ricochet-rs/ricochet#979](https://github.com/ricochet-rs/ricochet/pull/979), which sets a `securityContext` on spawned pods so new bundles land owned by gid 1000 in the first place.
This chart change is what unblocks clusters whose existing bundles are already root-owned.