### PR TITLE
perf: skip recursive chown when sentinel marks PVC as already healed

### DIFF
--- a/charts/ricochet/README.md
+++ b/charts/ricochet/README.md
@@ -1,6 +1,6 @@
 # ricochet-helm
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 ## Installation
 

--- a/charts/ricochet/templates/deployment.yaml
+++ b/charts/ricochet/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   return 0
                 fi
                 echo "[$dir] running chown -R $UID:$GID..."
-                chown -R "$UID:$GID" "$dir"
+                chown -R "$UID:$GID" "$dir" || { echo "[$dir] chown failed, sentinel NOT written — will retry on next start"; return 1; }
                 touch "$dir/$SENTINEL" && chown "$UID:$GID" "$dir/$SENTINEL"
                 echo "[$dir] healed and sentinel written"
               }

--- a/charts/ricochet/templates/deployment.yaml
+++ b/charts/ricochet/templates/deployment.yaml
@@ -51,13 +51,28 @@ spec:
           command: ['sh', '-c']
           args:
             - |
-              UID_GID="{{ .Values.podSecurityContext.runAsUser | default 1000 }}:{{ .Values.podSecurityContext.fsGroup | default 1000 }}"
-              chown -R "$UID_GID" {{ .Values.persistence.home.mountPath }}
+              UID="{{ .Values.podSecurityContext.runAsUser | default 1000 }}"
+              GID="{{ .Values.podSecurityContext.fsGroup | default 1000 }}"
+              SENTINEL=".ricochet-perms-fixed-{{ .Values.podSecurityContext.runAsUser | default 1000 }}-{{ .Values.podSecurityContext.fsGroup | default 1000 }}"
+
+              heal() {
+                dir="$1"
+                if [ -e "$dir/$SENTINEL" ]; then
+                  echo "[$dir] already healed for $UID:$GID, skipping recursive chown"
+                  return 0
+                fi
+                echo "[$dir] running chown -R $UID:$GID..."
+                chown -R "$UID:$GID" "$dir"
+                touch "$dir/$SENTINEL" && chown "$UID:$GID" "$dir/$SENTINEL"
+                echo "[$dir] healed and sentinel written"
+              }
+
+              heal {{ .Values.persistence.home.mountPath }}
               {{- if .Values.apps.deployment.persistence.content.enabled }}
-              chown -R "$UID_GID" {{ .Values.apps.deployment.persistence.content.mountPath }}
+              heal {{ .Values.apps.deployment.persistence.content.mountPath }}
               {{- end }}
               {{- if .Values.apps.deployment.persistence.cache.enabled }}
-              chown -R "$UID_GID" {{ .Values.apps.deployment.persistence.cache.mountPath }}
+              heal {{ .Values.apps.deployment.persistence.cache.mountPath }}
               {{- end }}
           securityContext:
             runAsUser: 0

--- a/charts/ricochet/tests/fix_permissions_test.yaml
+++ b/charts/ricochet/tests/fix_permissions_test.yaml
@@ -267,3 +267,6 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
           pattern: 'return 0'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'chown -R "\$UID:\$GID" "\$dir" \|\|'

--- a/charts/ricochet/tests/fix_permissions_test.yaml
+++ b/charts/ricochet/tests/fix_permissions_test.yaml
@@ -51,6 +51,9 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
           pattern: 'SENTINEL="\.ricochet-perms-fixed-2000-3000"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'heal /var/lib/ricochet/data'
 
   - it: also chowns and mounts the content PVC when enabled
     set:
@@ -261,3 +264,6 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
           pattern: 'touch "\$dir/\$SENTINEL"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'return 0'

--- a/charts/ricochet/tests/fix_permissions_test.yaml
+++ b/charts/ricochet/tests/fix_permissions_test.yaml
@@ -22,10 +22,16 @@ tests:
           content: CHOWN
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: 'UID_GID="1000:1000"'
+          pattern: 'UID="1000"'
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: 'chown -R "\$UID_GID" /var/lib/ricochet/data'
+          pattern: 'GID="1000"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'SENTINEL="\.ricochet-perms-fixed-1000-1000"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'heal /var/lib/ricochet/data'
 
   - it: uses custom uid/gid from podSecurityContext
     set:
@@ -38,7 +44,13 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: 'UID_GID="2000:3000"'
+          pattern: 'UID="2000"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'GID="3000"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'SENTINEL="\.ricochet-perms-fixed-2000-3000"'
 
   - it: also chowns and mounts the content PVC when enabled
     set:
@@ -53,7 +65,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: 'chown -R "\$UID_GID" /var/lib/ricochet/data/content'
+          pattern: 'heal /var/lib/ricochet/data/content'
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
@@ -73,7 +85,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: 'chown -R "\$UID_GID" /var/lib/ricochet/data/.cache'
+          pattern: 'heal /var/lib/ricochet/data/\.cache'
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
@@ -230,3 +242,22 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.securityContext.fsGroupChangePolicy
+
+  - it: defines the heal function that skips when sentinel matches
+    set:
+      persistence:
+        home:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'heal\(\) \{'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'if \[ -e "\$dir/\$SENTINEL" \]'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'chown -R "\$UID:\$GID" "\$dir"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'touch "\$dir/\$SENTINEL"'


### PR DESCRIPTION
## Summary

Makes the `fix-permissions-root` init container near-instant on restart for any PVC whose contents have already been healed to the current `runAsUser:fsGroup`.

**Why this matters:**

PR #51 made `fsGroupChangePolicy` adaptive so kubelet doesn't double-walk anymore — but the init container itself still ran `chown -R` from scratch on every restart. With #47 extending the init container to chown three PVCs (home + content + cache) and storage backends like Azure Files NFS doing each metadata op as a network round-trip, this stretched pod startup to 15+ minutes per restart on existing 10-100 GB trees — observed on every restart of a Posit-Connect-on-AKS test env with all three PVCs on `azurefiles-nfs-premium-retain`. Even with no actual permission drift to fix.

**What this PR does:**

Replaces the three straight-line `chown -R "$UID_GID" ...` calls with a POSIX-sh `heal()` function that checks for a per-PVC sentinel file at each mount root:

- Sentinel filename encodes the target UID:GID — `.ricochet-perms-fixed-1000-1000` for defaults. If you change `podSecurityContext.runAsUser` or `fsGroup`, the sentinel name changes, the old one doesn't match, and a fresh `chown -R` fires automatically.
- Sentinel is written only **after** `chown -R` exits zero. A partial NFS failure (`ESTALE` / `EACCES` mid-walk) causes `heal()` to return non-zero, the init container fails, and Kubernetes restarts the pod — exactly the existing "interrupted run safely re-tries" guarantee, now extended to silent failures too.
- Per-PVC sentinels (each PVC has its own at its own mount root) — selectively re-heal individual PVCs without nuking all skips.

**First start post-upgrade is unchanged** (no sentinel → full `chown -R` → sentinel written). Every restart after that becomes near-instant for any PVC whose ownership hasn't drifted.

**Escape hatch for forcing a re-heal** (after a manual restore or known drift event):

```bash
kubectl exec ... -- rm /var/lib/ricochet/data/.ricochet-perms-fixed-1000-1000
```

**Known caveat:** spawned-pod writers (per #47's commit) could still drop misowned files in content/cache after the first heal. The sentinel would hide that until manually invalidated. The structural fix — threading `securityContext` from chart values through `ricochet-proxy`'s K8s launcher into spawned pods — is still open separately. For clusters where this isn't a real risk (haven't observed spawned-pod misowned files), the sentinel skip is a strict speedup.
