### PR TITLE
chore: enable shared agent instructions

### DIFF
--- a/.crow/instructions.yaml
+++ b/.crow/instructions.yaml
@@ -1,0 +1,37 @@
+when:
+  - event: pull_request
+  - event: pull_request_edited
+  - event: push
+    branch:
+      - ${CI_REPO_DEFAULT_BRANCH}
+
+labels:
+  agent: thumper
+
+steps:
+  paired-pr:
+    when:
+      - event: pull_request
+      - event: pull_request_edited
+    image: reg.ricochet.rs/docker.io/library/alpine:3.24
+    environment:
+      GH_TOKEN:
+        from_secret: agent_instructions_token
+    commands:
+      - apk add -q --no-cache github-cli jq
+      - gh repo clone ricochet-rs/agent-instructions /tmp/agent-instructions -- --depth=1
+      - /tmp/agent-instructions/scripts/paired-instructions-pr.sh check "$${CI_REPO}" "$${CI_COMMIT_PULL_REQUEST}"
+
+  merge-paired-pr:
+    when:
+      - event: push
+        branch:
+          - ${CI_REPO_DEFAULT_BRANCH}
+    image: reg.ricochet.rs/docker.io/library/alpine:3.24
+    environment:
+      GH_TOKEN:
+        from_secret: agent_instructions_token
+    commands:
+      - apk add -q --no-cache github-cli jq
+      - gh repo clone ricochet-rs/agent-instructions /tmp/agent-instructions -- --depth=1
+      - /tmp/agent-instructions/scripts/paired-instructions-pr.sh merge-for-commit "$${CI_REPO}" "$${CI_COMMIT_SHA}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Codex instructions
+
+Before doing any work, read `CLAUDE.md` completely and follow it.
+If `CLAUDE.md` cannot be read, stop and report the failure.


### PR DESCRIPTION
This repository now loads current Ricochet organization guidance and enforces the paired-instructions lifecycle in CI.

<details>
<summary>AI Summary</summary>

This change adds the repository-neutral bootstrap for Codex and Claude while preserving existing repository-specific instructions.

The CI entry point clones `ricochet-rs/agent-instructions` from shared `main` at runtime and delegates validation and post-merge handling to the centralized checker.
Future checker fixes therefore land once in the shared repository rather than being copied across consumers.

Validation:

- Repository pre-commit hooks when configured
- CI configuration parsing or `crow lint`
- `git diff --check`

</details>

Instructions-PR: none
